### PR TITLE
Add basic compilation support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,7 @@
 source "https://rubygems.org"
 
 gem "graphviz"
+gem "fisk"
+gem "crabstone"
 gem "racc"
 gem "rake"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,10 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    crabstone (4.0.3)
+      ffi
     ffi (1.15.3)
+    fisk (2.0.0)
     graphviz (1.2.1)
       process-pipeline
     process-group (1.2.3)
@@ -17,6 +20,8 @@ PLATFORMS
   x86_64-darwin-19
 
 DEPENDENCIES
+  crabstone
+  fisk
   graphviz
   racc
   rake

--- a/bin/compile
+++ b/bin/compile
@@ -1,0 +1,55 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+$:.unshift(File.expand_path("../lib", __dir__))
+require "regular_expression"
+
+require "crabstone"
+
+pattern = RegularExpression.pattern(ARGV.shift)
+
+compiler = RegularExpression::Compiler.new
+compiled = compiler.compile(pattern.nfa)
+
+compiled.dump
+puts
+
+cfg_builder = RegularExpression::CFG::Builder.new
+cfg = cfg_builder.build(compiled)
+cfg.dump
+puts
+RegularExpression::CFG::Graph.to_dot(cfg)
+
+rubygen = RegularExpression::RubyGen.new
+ruby_src = rubygen.build(cfg)
+puts ruby_src
+puts
+
+ruby_proc = eval(ruby_src)
+
+ARGV.each do |string|
+  puts "#{string}: #{ruby_proc.call(string)}"
+end
+puts
+
+nativegen = RegularExpression::NativeGen.new
+native_code = nativegen.build(cfg)
+
+crabstone = Crabstone::Disassembler.new(Crabstone::ARCH_X86, Crabstone::MODE_64)
+crabstone.disasm(native_code.memory.to_s(native_code.pos), native_code.memory.to_i).each do |i|
+  printf "\t0x%<address>x:\t%<instruction>s\t%<details>s\n",
+    address: i.address,
+    instruction: i.mnemonic,
+    details: i.op_str
+end
+puts
+
+inner_proc = native_code.to_function([Fiddle::TYPE_VOIDP, Fiddle::TYPE_SIZE_T], Fiddle::TYPE_SIZE_T)
+
+native_proc = ->(string) {
+  inner_proc.call(string, string.size) == 1
+}
+
+ARGV.each do |string|
+  puts "#{string}: #{native_proc.call(string)}"
+end

--- a/bin/interpret
+++ b/bin/interpret
@@ -1,0 +1,16 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+$:.unshift(File.expand_path("../lib", __dir__))
+require "regular_expression"
+
+pattern = RegularExpression.pattern(ARGV.shift)
+
+compiler = RegularExpression::Compiler.new
+compiled = compiler.compile(pattern.nfa)
+
+interpreter = RegularExpression::Interpreter.new
+
+ARGV.each do |string|
+  puts "#{string}: #{interpreter.match?(compiled, string)}"
+end

--- a/lib/regular_expression.rb
+++ b/lib/regular_expression.rb
@@ -5,6 +5,12 @@ require_relative "./regular_expression/lexer"
 require_relative "./regular_expression/nfa"
 require_relative "./regular_expression/optimize"
 require_relative "./regular_expression/parser"
+require_relative "./regular_expression/bytecode"
+require_relative "./regular_expression/compiler"
+require_relative "./regular_expression/interpreter"
+require_relative "./regular_expression/cfg"
+require_relative "./regular_expression/rubygen"
+require_relative "./regular_expression/nativegen"
 
 module RegularExpression
   class Pattern

--- a/lib/regular_expression/bytecode.rb
+++ b/lib/regular_expression/bytecode.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module RegularExpression
+  # The Bytecode module defines instructions, and has a Compiled object for storing a stream of them, and a Builder
+  # object for creating the Compiled object.
+  module Bytecode
+
+    module Insns
+      Start = Class.new
+      Read = Struct.new(:char, :then)
+      Jump = Struct.new(:target)
+      Finish = Class.new
+      Fail = Class.new
+    end
+
+    class Builder
+
+      def initialize
+        @insns = []
+        @labels = {}
+      end
+
+      def mark_label(label)
+        @labels[label] = @insns.size
+      end
+
+      def push(insn)
+        @insns.push insn
+      end
+
+      def build
+        Compiled.new(@insns, @labels)
+      end
+
+    end
+
+    class Compiled
+
+      attr_reader :insns, :labels
+
+      def initialize(insns, labels)
+        @insns = insns
+        @labels = labels
+      end
+
+      def dump
+        # Labels store name -> address, but if we want to print the label name at its address, we need to store the
+        # address to the name as well.
+        reverse_labels = {}
+        @labels.each do |label, n|
+          reverse_labels[n] = label
+        end
+
+        @insns.each_with_index do |insn, n|
+          label = reverse_labels[n]
+          puts "#{label.to_s}:" if label
+          puts "  #{insn}"
+        end
+      end
+
+    end
+
+  end
+end

--- a/lib/regular_expression/cfg.rb
+++ b/lib/regular_expression/cfg.rb
@@ -1,0 +1,165 @@
+# frozen_string_literal: true
+
+require "set"
+
+module RegularExpression
+  # The CFG is a directed graph of extended basic blocks of bytecode instructions. This module has objects to represent
+  # the EBB, a graph object which contains a set of EBB, and a builder that creates a CFG from a Compiled bytecode
+  # object.
+  module CFG
+
+    # An Extended Basic Block is a linear sequence of instructions with one entry point and zero or more exit points.
+    class ExtendedBasicBlock
+
+      attr_reader :name, :insns, :exits
+
+      def initialize(name, insns, exits)
+        @name = name
+        @insns = insns
+        @exits = exits
+      end
+
+      def dump(exit_map)
+        puts "#{name}:"
+        @insns.each do |insn|
+          puts "  #{insn}"
+        end
+        @exits.each do |exit|
+          puts "    #{exit} -> #{exit_map[exit].name}"
+        end
+      end
+
+    end
+
+    # A graph is a set of EBBs.
+    class Graph
+
+      attr_reader :blocks, :exit_map
+
+      def initialize(blocks, exit_map)
+        @blocks = blocks
+        @exit_map = exit_map
+      end
+
+      def start
+        @blocks.first
+      end
+
+      def dump
+        @blocks.each do |block|
+          block.dump @exit_map
+        end
+      end
+
+      def to_dot(graph)
+        nodes = {}
+
+        @blocks.each do |block|
+          label = []
+          label.push "#{block.name}:"
+          block.insns.each do |insn|
+            label.push "  #{insn.to_s}"
+          end
+          nodes[block] = graph.add_node(block.object_id, label: label.join($/), labeljust: "l", shape: "box")
+        end
+
+        @blocks.each do |block|
+          successors = block.exits.map { |exit| nodes[@exit_map[exit]] }.uniq
+          successors.each do |successor|
+            nodes[block].connect successor
+          end
+        end
+      end
+
+      def self.to_dot(cfg)
+        require "graphviz"
+        graph = Graphviz::Graph.new
+        cfg.to_dot(graph)
+
+        Graphviz.output(graph, path: "build/cfg.svg", format: "svg")
+        graph.to_dot
+      end
+
+    end
+
+    class Builder
+
+      def build(compiled)
+        # Each label in the compiled bytecode starts a block, as does the first instruction
+        all_blocks = {start: 0}.merge(compiled.labels)
+        all_block_addresses = all_blocks.values
+
+        # We're going to create a potentially larger map of labels, and we'll be maintaining a reverse map as well.
+        all_labels = compiled.labels.dup
+        all_labels_reverse = Hash[all_labels.to_a.map(&:reverse)]
+
+        # These are the blocks we're finding - indexed by their start address.
+        blocks = {}
+
+        # Go through each block.
+        all_blocks.each do |name, start_n|
+          # We're goign to collect up the instructions in the block, and the labels it exits to.
+          block_insns = []
+          block_exits = Set.new
+
+          insn_n = start_n
+          loop do
+            # Does another instruction jump here? If so it's the end of the EBB, as EBBs have only one entry point.
+            if insn_n != start_n && all_block_addresses.include?(insn_n)
+              # As the EBB ends here - we should jump to the next EBB.
+              target = all_labels_reverse[insn_n]
+              unless target
+                target = :"extra#{insn_n}"
+                all_labels[target] = insn_n
+                all_labels_reverse[insn_n] = target
+              end
+              block_insns.push Bytecode::Insns::Jump.new(target)
+              block_exits.add target
+              break
+            end
+
+            # Examine each instruction.
+            insn = compiled.insns[insn_n]
+            block_insns.push insn
+            case insn
+            when Bytecode::Insns::Start
+              insn_n += 1
+              next
+            when Bytecode::Insns::Read
+              # Remember this block exits to this target.
+              block_exits.add insn.then
+              insn_n += 1
+              next
+            when Bytecode::Insns::Jump
+              # Remember this block exits to this target.
+              block_exits.add insn.target
+              break
+            when Bytecode::Insns::Finish
+              # Ends the block.
+              break
+            when Bytecode::Insns::Fail
+              # Ends the block.
+              break
+            else
+              raise
+            end
+          end
+
+          blocks[start_n] = ExtendedBasicBlock.new(name, block_insns, block_exits.to_a)
+        end
+
+        # Create a map of jump target labels to the blocks that contain them.
+        exit_map = {}
+        blocks.each_value do |block|
+          block.exits.each do |exit|
+            exit_map[exit] ||= blocks[all_labels[exit]]
+          end
+        end
+
+        Graph.new(blocks.values, exit_map)
+      end
+
+    end
+
+  end
+end

--- a/lib/regular_expression/compiler.rb
+++ b/lib/regular_expression/compiler.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "set"
+
+module RegularExpression
+  # The Compiler module translate an NFA to compiled bytecode through abstract interpretation.
+  class Compiler
+
+    def compile(nfa)
+      builder = Bytecode::Builder.new
+
+      # For each state in the NFA.
+      states(nfa).each do |state|
+        # Label the start of the state.
+        builder.mark_label :"state#{state.object_id}"
+        case state
+        when NFA::FinishState
+          # Finish state is a finish instruction.
+          builder.push Bytecode::Insns::Finish.new
+        when NFA::State
+          # Other states have transitions out of them. Go through each transition.
+          state.transitions.each do |transition|
+            case transition
+            when NFA::Transition::Set
+              # For the set transition, we want to try to read the given character, and if we find it, jump to the
+              # target state's code.
+              raise unless transition.values.size == 1
+              raise if transition.invert
+              builder.push Bytecode::Insns::Read.new(transition.values.first, :"state#{transition.state.object_id}")
+            when NFA::Transition::Epsilon
+              # Handled below.
+            else
+              raise
+            end
+          end
+
+          # Do we have an epsilon transition? If so we handle it last, as fallthrough.
+          epsilon_transition = state.transitions.find { |t| t.is_a?(NFA::Transition::Epsilon) }
+          if epsilon_transition
+            # Jump to the state the epsilon transition takes us to.
+            builder.push Bytecode::Insns::Jump.new(:"state#{epsilon_transition.state.object_id}")
+          else
+            # With no epsilon transition, no transitions match, which means we jump to the failure case.
+            builder.push Bytecode::Insns::Jump.new(:fail)
+          end
+        else
+          raise
+        end
+      end
+
+      # We always have a fialure case - it's just the failure instruction.
+      builder.mark_label :fail
+      builder.push Bytecode::Insns::Fail.new
+
+      builder.build
+    end
+
+    # Get all the states in the NFA.
+    def states(nfa)
+      states = Set.new
+      worklist = [nfa]
+
+      # Never recurse a graph in a compiler! We don't know how deep it is and don't want to limit how large a program
+      # we can accept due to arbitrary stack space. Always use a worklist.
+      until worklist.empty?
+        state = worklist.pop
+        next if states.include?(state)
+        states.add state
+        worklist.push *state.transitions.map(&:state)
+      end
+
+      states.to_a
+    end
+
+  end
+end

--- a/lib/regular_expression/interpreter.rb
+++ b/lib/regular_expression/interpreter.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module RegularExpression
+  # An interpreter for our compiled bytecode. Maybe we could make this possible to enter at a given state and deoptimise
+  # to it from the compiled code?
+  class Interpreter
+
+    def match?(compiled, string)
+      start_n = 0
+      while start_n < string.size
+        string_n = start_n
+        insn_n = 0
+        while true
+          insn = compiled.insns[insn_n]
+          case insn
+          when Bytecode::Insns::Start
+            insn_n += 1
+          when Bytecode::Insns::Read
+            if string[string_n] == insn.char
+              string_n += 1
+              insn_n = compiled.labels[insn.then]
+            else
+              insn_n += 1
+            end
+          when Bytecode::Insns::Jump
+            insn_n = compiled.labels[insn.target]
+          when Bytecode::Insns::Finish
+            return true
+          when Bytecode::Insns::Fail
+            break
+          else
+            raise
+          end
+        end
+        start_n += 1
+      end
+      false
+    end
+
+  end
+end

--- a/lib/regular_expression/nativegen.rb
+++ b/lib/regular_expression/nativegen.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require "fisk"
+require "fisk/helpers"
+
+module RegularExpression
+  class NativeGen
+
+    # Generate native code for a CFG. This looks just like the Ruby generator but abstracted one level, or just like
+    # the interpreter but abstracted two levels!
+    def build(cfg)
+      fisk = Fisk.new
+      jitbuf = Fisk::Helpers.jitbuffer(1024)
+      fisk.asm(jitbuf) do
+        # rdi (string) = arg[0]
+        # rsi (string.size) = arg[1]
+        push rbp
+        mov rbp, rsp
+
+        # rdx (start_n) = 0
+        mov rdx, imm64(0)
+
+        # while rdx (start_n) < rsi (string.size)
+        make_label :start_loop_head
+        cmp rdx, rsi
+        jge label(:search_loop_exit)
+
+        # rcx (string_n) = (rdx) start_n
+        mov rcx, rdx
+
+        cfg.blocks.each do |block|
+          make_label block.name
+
+          block.insns.each do |insn|
+            case insn
+            when Bytecode::Insns::Start
+              next
+            when Bytecode::Insns::Read
+              # if string (rdi)[string_n (rcx)] == char
+              mov r8, rdi
+              add r8, rcx
+              mov r8, m64(r8)
+              cmp r8, imm8(insn.char.ord) # I want to do rdi[rcx] but can't figure out how in Fisk
+              no_match_label = :"no_match_#{insn.object_id}"
+              jne label(no_match_label)
+
+              # rcx (string_n) += 1
+              inc rcx
+
+              # goto next block
+              jmp label(cfg.exit_map[insn.then].name)
+
+              make_label no_match_label
+            when Bytecode::Insns::Jump
+              jmp label(cfg.exit_map[insn.target].name)
+            when Bytecode::Insns::Finish
+              # return 1
+              mov rax, imm64(1)
+              pop rbp
+              ret
+            when Bytecode::Insns::Fail
+              # rdx (start_n) += 1
+              inc rdx
+
+              jmp label(:start_loop_head)
+            else
+              raise
+            end
+          end
+        end
+
+        # exit_search_loop:
+        make_label :search_loop_exit
+
+        mov rax, imm64(0)
+        pop rbp
+        ret
+      end
+    end
+
+  end
+end

--- a/lib/regular_expression/rubygen.rb
+++ b/lib/regular_expression/rubygen.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module RegularExpression
+  class RubyGen
+
+    # Generate Ruby code for a CFG. This looks just like the intepreter, but abstracted in time one level!
+    def build(cfg)
+      ruby_src = []
+      ruby_src.push "->string {"
+      ruby_src.push "  start_n = 0"
+      ruby_src.push "  while start_n < string.size"
+      ruby_src.push "    string_n = start_n"
+      ruby_src.push "    block = #{cfg.start.name.inspect}"
+      ruby_src.push "    while true"
+      ruby_src.push "      case block"
+
+      cfg.blocks.each do |block|
+        ruby_src.push "      when #{block.name.inspect}"
+        block.insns.each do |insn|
+          case insn
+          when Bytecode::Insns::Start
+            next
+          when Bytecode::Insns::Read
+            ruby_src.push "        if string[string_n] == #{insn.char.inspect}"
+            ruby_src.push "          string_n += 1"
+            ruby_src.push "          block = #{cfg.exit_map[insn.then].name.inspect}"
+            ruby_src.push "          next"
+            ruby_src.push "        end"
+          when Bytecode::Insns::Jump
+            ruby_src.push "        block = #{cfg.exit_map[insn.target].name.inspect}"
+            ruby_src.push "        next"
+          when Bytecode::Insns::Finish
+            ruby_src.push "        return true"
+          when Bytecode::Insns::Fail
+            ruby_src.push "        start_n += 1"
+            ruby_src.push "        break"
+          else
+            raise
+          end
+        end
+      end
+
+      ruby_src.push "      end"
+      ruby_src.push "    end"
+      ruby_src.push "  end"
+      ruby_src.push "  false"
+      ruby_src.push "}"
+      ruby_src.join($/)
+    end
+
+  end
+end


### PR DESCRIPTION
This adds basic support for compilation to bytecode, a bytecode interpreter, a control-flow-graph phase, and code generation for both Ruby and native AMD64.

With a working example of the pattern `ab?c`.

We compile the NFA to a simple bytecode via abstract interpretation:

```
state1160:
  #<struct RegularExpression::Bytecode::Insns::Read char="a", then=:state1180>
  #<struct RegularExpression::Bytecode::Insns::Jump target=:fail>
state1180:
  #<struct RegularExpression::Bytecode::Insns::Read char="b", then=:state1200>
  #<struct RegularExpression::Bytecode::Insns::Jump target=:state1200>
state1200:
  #<struct RegularExpression::Bytecode::Insns::Read char="c", then=:state1220>
  #<struct RegularExpression::Bytecode::Insns::Jump target=:fail>
state1220:
  #<RegularExpression::Bytecode::Insns::Finish:0x00007fa1c857e5b0>
fail:
  #<RegularExpression::Bytecode::Insns::Fail:0x00007fa1c857e510>
```

We then build a control-flow-graph of this by basic control-flow analysis:

```
state1160:
  #<struct RegularExpression::Bytecode::Insns::Read char="a", then=:state1180>
  #<struct RegularExpression::Bytecode::Insns::Jump target=:fail>
    state1180 -> state1180
    fail -> fail
state1180:
  #<struct RegularExpression::Bytecode::Insns::Read char="b", then=:state1200>
  #<struct RegularExpression::Bytecode::Insns::Jump target=:state1200>
    state1200 -> state1200
state1200:
  #<struct RegularExpression::Bytecode::Insns::Read char="c", then=:state1220>
  #<struct RegularExpression::Bytecode::Insns::Jump target=:fail>
    state1220 -> state1220
    fail -> fail
state1220:
  #<RegularExpression::Bytecode::Insns::Finish:0x00007fa1c857e5b0>
fail:
  #<RegularExpression::Bytecode::Insns::Fail:0x00007fa1c857e510>
```

<img width="1340" alt="Screenshot 2021-07-04 at 21 39 15" src="https://user-images.githubusercontent.com/341094/124398941-4c0bf780-dd10-11eb-8333-0dcba3cc9175.png">

From this we can automatically generate Ruby code to match the pattern:

```ruby
->string {
  start_n = 0
  while start_n < string.size
    string_n = start_n
    block = :state1160
    while true
      case block
      when :state1160
        if string[string_n] == "a"
          string_n += 1
          block = :state1180
          next
        end
        block = :fail
        next
      when :state1180
        if string[string_n] == "b"
          string_n += 1
          block = :state1200
          next
        end
        block = :state1200
        next
      when :state1200
        if string[string_n] == "c"
          string_n += 1
          block = :state1220
          next
        end
        block = :fail
        next
      when :state1220
        return true
      when :fail
        start_n += 1
        break
      end
    end
  end
  false
}
```

And we can also automatically generate AMD64 machine code:

```s
	0x10ad87000:	push	rbp
	0x10ad87001:	mov	rbp, rsp
	0x10ad87004:	movabs	rdx, 0
	0x10ad8700e:	cmp	rdx, rsi
	0x10ad87011:	jge	0x10ad8708b
	0x10ad87017:	mov	rcx, rdx
	0x10ad8701a:	mov	r8, rdi
	0x10ad8701d:	add	r8, rcx
	0x10ad87020:	mov	r8, qword ptr [r8]
	0x10ad87023:	cmp	r8b, 0x61
	0x10ad87027:	jne	0x10ad87035
	0x10ad8702d:	inc	rcx
	0x10ad87030:	jmp	0x10ad8703a
	0x10ad87035:	jmp	0x10ad87086
	0x10ad8703a:	mov	r8, rdi
	0x10ad8703d:	add	r8, rcx
	0x10ad87040:	mov	r8, qword ptr [r8]
	0x10ad87043:	cmp	r8b, 0x62
	0x10ad87047:	jne	0x10ad87055
	0x10ad8704d:	inc	rcx
	0x10ad87050:	jmp	0x10ad8705a
	0x10ad87055:	jmp	0x10ad8705a
	0x10ad8705a:	mov	r8, rdi
	0x10ad8705d:	add	r8, rcx
	0x10ad87060:	mov	r8, qword ptr [r8]
	0x10ad87063:	cmp	r8b, 0x63
	0x10ad87067:	jne	0x10ad87075
	0x10ad8706d:	inc	rcx
	0x10ad87070:	jmp	0x10ad8707a
	0x10ad87075:	jmp	0x10ad87086
	0x10ad8707a:	movabs	rax, 1
	0x10ad87084:	pop	rbp
	0x10ad87085:	ret	
	0x10ad87086:	inc	rdx
	0x10ad87089:	jmp	0x10ad8700e
	0x10ad8708b:	movabs	rax, 0
	0x10ad87095:	pop	rbp
	0x10ad87096:	ret	
```

All these execution methods (interpreter, Ruby, native) generate the same results for simple test patterns:

```
ac: true
abc: true
xabc: true
axc: false
```

Uses Fisk @tenderlove as an assembler, and Crabstone as a disassembler.